### PR TITLE
référence le owncloud de la mshe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # owncloud-themeMSHE
+
+Thème ownCloud pour https://owncloud-mshe.univ-fcomte.fr


### PR DESCRIPTION
référence le owncloud de la mshe pour aider à le retrouver par les moteurs de recherche (plus agréable pour les utilisateurs)